### PR TITLE
feat: verified provider capability registry

### DIFF
--- a/docs/2026-09-11-provider-capability-registry-design.md
+++ b/docs/2026-09-11-provider-capability-registry-design.md
@@ -1,0 +1,49 @@
+# Curated Provider Capability Registry
+
+**Status:** Approved 2026-09-11
+
+## Goal
+
+Make Add Connection trustworthy: only verified providers appear in the primary catalogue, every preset carries its real connection metadata, and model/usage capabilities are stated honestly.
+
+## Product decisions
+
+1. The primary catalogue is curated. Existing connections are never removed or disabled by catalogue changes.
+2. A provider qualifies when its endpoint/auth/model-discovery contract has evidence and can be exercised by the connection test.
+3. Real usage is optional. Providers without a public usage API remain eligible, but display `Usage not provided by provider` rather than an error or fabricated usage.
+4. Save remains gated by a successful test. A successful save automatically syncs models and reports partial post-save failures clearly.
+
+## Architecture
+
+Extend `provider_presets` with connection metadata and capability/evidence fields. A typed catalogue in Go is the source for built-ins; the seeder refreshes all built-in metadata in place while preserving manual presets. The dashboard copies the complete preset contract into the connection form and sends it to both Test and Save.
+
+Capability values:
+
+- `models`: `supported` or `unsupported`
+- `usage`: `full`, `rate_limits`, or `not_provided`
+- `verification_status`: `verified` or `unverified`
+- `verified_at`: date of latest endpoint/contract verification
+
+The primary Add Connection list shows only built-ins marked verified with model discovery supported, plus user-created custom presets. Capability badges explain what is available.
+
+## Initial curated cohort
+
+The initial cohort is intentionally conservative and based on current implementation/evidence: OpenAI, Anthropic, Google AI, xAI, Mistral, DeepSeek, Qwen, Moonshot, Zhipu, Groq, Together, Fireworks, OpenRouter, Perplexity, Ollama, Xiaomi MiMo, NVIDIA, Cerebras, Kilo Gateway, TokenRouter, SambaNova, SiliconFlow, DeepInfra, Jina AI, Baseten, Novita AI, CommandCode Alpha, and existing custom presets whose owner explicitly created them.
+
+Provider-specific metadata must override generic path derivation. Anthropic uses `x-api-key` plus `anthropic-version`; Gemini uses its OpenAI-compatible surface for this connection flow; CommandCode Alpha uses `/alpha/generate` and `/provider/v1/models`.
+
+## Error handling
+
+- Unsupported usage is a successful capability result, not an HTTP/provider failure.
+- Authentication, malformed response, unavailable endpoint, and timeout remain errors.
+- If connection creation succeeds but model sync fails, keep the connection and show a warning with a retry action; never roll back or delete credentials silently.
+- Unknown custom providers use generic OpenAI-compatible paths and `usage=not_provided`.
+
+## Verification
+
+- Migration/backfill tests for existing databases.
+- Catalogue contract tests: every curated preset has paths/auth/capabilities/evidence.
+- Provider-specific tests for Anthropic, Gemini/OpenAI-compatible, CommandCode Alpha, and standard `/v1` providers.
+- Handler tests proving test and save consume identical metadata.
+- Frontend build and source/DOM behavior checks.
+- Full Go suite and production-like isolated smoke before any deployment.

--- a/docs/plans/2026-09-11-provider-capability-registry.md
+++ b/docs/plans/2026-09-11-provider-capability-registry.md
@@ -1,0 +1,66 @@
+# Provider Capability Registry Implementation Plan
+
+> **For Hermes:** Implement task-by-task with strict RED-GREEN-REFACTOR.
+
+**Goal:** Replace the broad URL-only preset list with a curated, capability-aware catalogue whose metadata drives connection test, save, model sync, and honest usage display.
+
+**Architecture:** Extend the preset schema and Go catalogue with connection-contract fields. Keep one DB-backed API for the dashboard, preserve custom presets, and make frontend form state carry the full selected contract. Usage capability is descriptive and separate from runtime provider errors.
+
+**Tech Stack:** Go, SQLite, SvelteKit 5, TypeScript.
+
+---
+
+### Task 1: Schema and migration
+
+**Files:** `internal/db/db.go`, DB migration tests.
+
+1. Write a failing migration test for new preset columns and legacy-row backfill.
+2. Run the focused test and confirm expected missing-column failure.
+3. Add additive columns: chat/models paths, auth metadata, extra headers, model/usage capabilities, verification status/date.
+4. Rerun focused test.
+
+### Task 2: Typed curated catalogue
+
+**Files:** `internal/server/handlers_presets.go`, catalogue tests.
+
+1. Write failing contracts requiring every curated built-in to have valid model metadata and verification evidence.
+2. Add fields to `Preset`; replace unverified primary entries with a conservative curated cohort.
+3. Encode provider-specific contracts for Anthropic, Gemini OpenAI-compatible endpoint, and CommandCode Alpha.
+4. Update seeding to refresh all built-in metadata while preserving manual rows.
+5. Rerun focused tests.
+
+### Task 3: Preset CRUD/API parity
+
+**Files:** `internal/server/handlers_presets.go`, handler tests.
+
+1. Add failing JSON round-trip and CRUD tests for capability fields.
+2. Update SELECT/INSERT/UPDATE payloads.
+3. Verify API response and manual preset defaults.
+
+### Task 4: Connection test and save parity
+
+**Files:** `frontend/src/routes/dashboard/connections/+page.svelte`, relevant Go handler tests.
+
+1. Add failing source/handler tests proving complete preset metadata reaches test and save.
+2. Expand form state and `pickPreset`.
+3. Send snake/camel-compatible path/auth/header metadata to test and save.
+4. After successful creation, sync models automatically; report sync failure as warning while preserving connection.
+5. Verify focused tests.
+
+### Task 5: Capability UX
+
+**Files:** `frontend/src/routes/dashboard/connections/+page.svelte`.
+
+1. Add source-level regression tests for filtering and labels.
+2. Show only verified/model-supported built-ins plus manual presets.
+3. Render Models and Usage capability badges.
+4. Render `Usage not provided by provider` as neutral state rather than failure.
+5. Build frontend.
+
+### Task 6: Review and verification
+
+1. Run adversarial fresh-context review of schema compatibility, capability truthfulness, and failure modes.
+2. Reconcile valid findings.
+3. Run focused tests, `go test ./...`, frontend checks/build, and `git diff --check`.
+4. Run isolated binary smoke and browser QA without modifying production.
+5. Commit, rebase on `origin/main`, rerun verification, push branch, and submit for review before any production deployment.

--- a/frontend/src/routes/dashboard/connections/+page.svelte
+++ b/frontend/src/routes/dashboard/connections/+page.svelte
@@ -14,7 +14,7 @@
   import { showToast } from '$lib/toast';
   import { OAUTH_IDE_PRESETS, type OAuthIdePreset } from '$lib/oauthIdePresets';
   import { brandForProvider, logoPaths } from '$lib/oauthIdeBrands';
-  import { Link2, Plus, TestTube2, RefreshCw, Trash2, ToggleLeft, ToggleRight, X, Search, Check, Sparkles, Settings, Edit2, Pencil, Save, FolderTree, Eye, EyeOff, Copy, Box, Cpu, ShieldAlert, Layers, ChevronRight, Zap, CheckCircle2, AlertCircle, TriangleAlert } from 'lucide-svelte';
+  import { Link2, Plus, TestTube2, RefreshCw, Trash2, ToggleLeft, ToggleRight, X, Search, Check, Sparkles, Settings, Edit2, Pencil, Save, FolderTree, Eye, EyeOff, Copy, Box, Cpu, ShieldAlert, Layers, ChevronRight, ChevronDown, Zap, CheckCircle2, AlertCircle, TriangleAlert } from 'lucide-svelte';
 
   let connections = $state<any[]>([]);
   let loading = $state(true);
@@ -25,6 +25,7 @@
   // Balance/credit state
   let balances = $state<Record<string, any>>({});
   let balancesLoading = $state(false);
+  let expandedBalance = $state<string | null>(null);
   let syncing = $state<string | null>(null);
   let presetSearch = $state('');
 
@@ -111,6 +112,20 @@
     if (n >= 1000000) return (n / 1000000).toFixed(1) + 'M';
     if (n >= 1000) return (n / 1000).toFixed(1) + 'k';
     return String(n);
+  }
+
+  // Worst-case limit pressure across a connection's rate windows → drive inline chip color.
+  function limitSeverity(bal: any): 'ok' | 'warn' | 'critical' {
+    if (!bal?.rate_windows?.length) return 'ok';
+    let worst: 'ok' | 'warn' | 'critical' = 'ok';
+    for (const w of bal.rate_windows) {
+      if (w.exceeded) return 'critical';
+      if (w.cap > 0) {
+        const pct = w.used / w.cap;
+        if (pct >= 0.8) worst = 'warn';
+      }
+    }
+    return worst;
   }
 
   function getProviderDomain(key: string, baseURL: string): string {
@@ -2149,11 +2164,25 @@
                         <span class="conn-card-oauth">OAuth:{conn.oauth_provider}</span>
                       {/if}
 
-                      {#if balances[conn.id]?.balance && !balances[conn.id]?.rate_windows?.length}
+                      {#if balances[conn.id]?.rate_windows?.length}
+                        {@const sev = limitSeverity(balances[conn.id])}
+                        <button
+                          class="conn-limit-chip"
+                          class:limit-warn={sev === 'warn'}
+                          class:limit-critical={sev === 'critical'}
+                          onclick={() => expandedBalance = expandedBalance === conn.id ? null : conn.id}
+                          title="Click for usage detail"
+                        >
+                          {#each balances[conn.id].rate_windows as win}
+                            <span class="conn-limit-seg">{winLabel(win.name)} {Math.round(win.used)}/{Math.round(win.cap)}</span>
+                          {/each}
+                          <span class="conn-limit-chev" class:open={expandedBalance === conn.id}><ChevronDown size={11} /></span>
+                        </button>
+                      {:else if balances[conn.id]?.balance}
                         <span class="badge conn-balance-badge" title="Credit: {balances[conn.id].balance}">
                           💰 {balances[conn.id].balance}
                         </span>
-                      {:else if balances[conn.id]?.rate_info && !balances[conn.id]?.rate_windows?.length}
+                      {:else if balances[conn.id]?.rate_info}
                         <span class="badge conn-rate-badge" title={balances[conn.id].rate_info}>
                           ⚡ {balances[conn.id].rate_info}
                         </span>
@@ -2234,7 +2263,7 @@
                       </div>
                     </div>
                   </div>
-                  {#if balances[conn.id]?.rate_windows?.length}
+                  {#if balances[conn.id]?.rate_windows?.length && expandedBalance === conn.id}
                     <div class="conn-balance-detail">
                       <div class="conn-balance-detail-header">
                         {#if balances[conn.id].balance}
@@ -3463,6 +3492,50 @@
     font-family: var(--font-mono);
     flex-shrink: 0;
     cursor: help;
+  }
+  .conn-limit-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 10px;
+    font-family: var(--font-mono);
+    padding: 2px 6px;
+    border-radius: 5px;
+    border: 1px solid rgba(16,185,129,0.35);
+    background: rgba(16,185,129,0.08);
+    color: var(--color-success);
+    cursor: pointer;
+    flex-shrink: 0;
+    white-space: nowrap;
+    transition: all 0.12s ease;
+  }
+  .conn-limit-chip:hover {
+    background: rgba(16,185,129,0.14);
+    border-color: rgba(16,185,129,0.5);
+  }
+  .conn-limit-chip .conn-limit-seg + .conn-limit-seg {
+    margin-left: 2px;
+  }
+  .conn-limit-chip.limit-warn {
+    border-color: rgba(245,158,11,0.4);
+    background: rgba(245,158,11,0.1);
+    color: #d97706;
+  }
+  .conn-limit-chip.limit-critical {
+    border-color: rgba(239,68,68,0.4);
+    background: rgba(239,68,68,0.1);
+    color: var(--color-error, #ef4444);
+  }
+  .conn-limit-chip :global(svg) {
+    transition: transform 0.12s ease;
+  }
+  .conn-limit-chev {
+    display: inline-flex;
+    align-items: center;
+    transition: transform 0.12s ease;
+  }
+  .conn-limit-chev.open {
+    transform: rotate(180deg);
   }
   .conn-rate-badge {
     font-size: 10px;

--- a/frontend/src/routes/dashboard/connections/+page.svelte
+++ b/frontend/src/routes/dashboard/connections/+page.svelte
@@ -367,7 +367,9 @@
   let reassigningPool = $state<string | null>(null); // connection id being reassigned
   let poolReassignTarget = $state(''); // target pool_id for reassign
 
-  let form = $state({ name: '', base_url: '', api_key: '', format: 'openai', priority: 1, oauth_provider: '' as string, pool_id: '' as string });
+  const emptyConnectionForm = () => ({ name: '', base_url: '', api_key: '', format: 'openai', priority: 1, oauth_provider: '' as string, pool_id: '' as string,
+    chat_path: '', models_path: '', auth_header: 'Authorization', auth_prefix: 'Bearer ', extra_headers: '{}' });
+  let form = $state(emptyConnectionForm());
 
   // Test-before-save state for the new-connection form
   let testingForm = $state(false);
@@ -382,7 +384,25 @@
     models_count?: number;
     fallback?: string;
   } | null>(null);
+  let testedFormFingerprint = $state('');
   let testBounce = $state(false); // triggers bounce animation on Test button
+
+  function connectionFormFingerprint() {
+    return JSON.stringify({
+      name: form.name,
+      base_url: form.base_url,
+      api_key: form.api_key,
+      format: form.format,
+      priority: form.priority,
+      oauth_provider: form.oauth_provider,
+      pool_id: form.pool_id,
+      chat_path: form.chat_path,
+      models_path: form.models_path,
+      auth_header: form.auth_header,
+      auth_prefix: form.auth_prefix,
+      extra_headers: form.extra_headers
+    });
+  }
 
   const summary = $derived({
     total: connections.length,
@@ -440,13 +460,12 @@
 
   function pickOAuthIdePreset(p: OAuthIdePreset) {
     form = {
+      ...emptyConnectionForm(),
       name: p.name,
       base_url: p.base_url,
-      api_key: '',
       format: p.format,
       priority: 5,
-      oauth_provider: p.oauth_provider,
-      pool_id: ''
+      oauth_provider: p.oauth_provider
     };
     testResult = null;
     showForm = true;
@@ -498,9 +517,15 @@
       format: preset.format,
       priority: 1,
       oauth_provider: '',
-      pool_id: ''
+      pool_id: '',
+      chat_path: preset.chat_path || '',
+      models_path: preset.models_path || '',
+      auth_header: preset.auth_header || 'Authorization',
+      auth_prefix: preset.auth_prefix ?? 'Bearer ',
+      extra_headers: preset.extra_headers || '{}'
     };
     testResult = null; // reset prior test result when picking a new preset
+    testedFormFingerprint = '';
     showForm = true;
     setTimeout(() => {
       const formEl = document.getElementById('add-connection-form');
@@ -1205,12 +1230,18 @@
     setTimeout(() => { testBounce = false; }, 600);
     testingForm = true;
     testResult = null;
+    testedFormFingerprint = '';
     try {
       const res = await api.post<any>('/api/connections/test', {
         base_url: form.base_url,
         api_key: formUsesOAuth ? '' : form.api_key,
         format: form.format,
-        oauth_provider: form.oauth_provider || undefined
+        oauth_provider: form.oauth_provider || undefined,
+        chat_path: form.chat_path,
+        models_path: form.models_path,
+        auth_header: form.auth_header,
+        auth_prefix: form.auth_prefix,
+        extra_headers: form.extra_headers
       });
       // Capture the full standard envelope
       testResult = {
@@ -1231,6 +1262,9 @@
             form.name = u.hostname.replace(/^api\./, '').replace(/\./g, '-');
           } catch { /* ignore */ }
         }
+        // Name auto-fill is a product-owned consequence of the successful
+        // test, so capture the final state. Any later user edit invalidates it.
+        testedFormFingerprint = connectionFormFingerprint();
       } else {
         // Toast gets a compact summary; the inline banner shows the full details
         const e = testResult.error;
@@ -1267,25 +1301,36 @@
   async function createConn() {
     // Save is blocked until test passes. Clicking the disabled-looking Save
     // button triggers a bounce on the Test button to draw the user's eye.
-    if (!testResult?.success) {
+    if (!testResult?.success || testedFormFingerprint !== connectionFormFingerprint()) {
       // Trigger bounce on Test button
       testBounce = true;
       setTimeout(() => { testBounce = false; }, 600);
       return;
     }
     try {
-      await api.post<any>('/api/connections', form);
+      const created = await api.post<any>('/api/connections', form);
+      const connectionId = created?.data?.id || created?.id;
+      if (connectionId) {
+        try {
+          await api.post('/api/models/sync/' + connectionId);
+          showToast('Connection saved · models synced', 'success');
+        } catch (syncError: any) {
+          showToast('Connection saved · model sync needs retry: ' + (syncError?.message || 'unknown error'), 'warning', 6000);
+        }
+      }
       await fetchConnections();
       showForm = false;
-      form = { name: '', base_url: '', api_key: '', format: 'openai', priority: 1, oauth_provider: '', pool_id: '' };
+      form = emptyConnectionForm();
       testResult = null;
+      testedFormFingerprint = '';
     } catch (e: any) { error = e.message; }
   }
 
   function cancelForm() {
     showForm = false;
-    form = { name: '', base_url: '', api_key: '', format: 'openai', priority: 1, oauth_provider: '', pool_id: '' };
+    form = emptyConnectionForm();
     testResult = null;
+    testedFormFingerprint = '';
     testingForm = false;
     testBounce = false;
   }
@@ -1698,7 +1743,10 @@
                     />
                     <div style="min-width: 0; flex: 1;">
                       <div style="font-size: 11px; font-weight: 600; color: var(--color-fg-0); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">{preset.name}</div>
-                      <div style="font-size: 9px; color: var(--color-fg-3); text-transform: uppercase;">{preset.format}</div>
+                      <div style="font-size: 9px; color: var(--color-fg-3); text-transform: uppercase;">{preset.format} · Models ✓</div>
+                      <div style="font-size: 9px; color: var(--color-fg-3);">
+                        {preset.usage_capability === 'full' ? 'Usage: Full' : preset.usage_capability === 'rate_limits' ? 'Usage: Rate limits' : 'Usage not provided by provider'}
+                      </div>
                     </div>
                   </button>
                 {/each}

--- a/frontend/src/routes/dashboard/connections/+page.svelte
+++ b/frontend/src/routes/dashboard/connections/+page.svelte
@@ -100,6 +100,19 @@
     return clean.slice(0, 7) + '...' + clean.slice(-4);
   }
 
+  function winLabel(name: string): string {
+    if (name === '5-hour') return '🕐 5h';
+    if (name === 'weekly') return '📅 Week';
+    if (name === 'daily') return '📅 Day';
+    return name;
+  }
+
+  function fmtTokens(n: number): string {
+    if (n >= 1000000) return (n / 1000000).toFixed(1) + 'M';
+    if (n >= 1000) return (n / 1000).toFixed(1) + 'k';
+    return String(n);
+  }
+
   function getProviderDomain(key: string, baseURL: string): string {
     const k = (key || '').toLowerCase();
     if (k.includes('xai') || k === 'x') return 'x.ai';
@@ -2221,6 +2234,37 @@
                       </div>
                     </div>
                   </div>
+                  {#if balances[conn.id]?.rate_windows?.length}
+                    <div class="conn-balance-detail">
+                      <div class="conn-balance-detail-header">
+                        {#if balances[conn.id].balance}
+                          <span class="conn-balance-credit">💰 {balances[conn.id].balance}</span>
+                        {/if}
+                        {#if balances[conn.id].plan_type}
+                          <span class="conn-balance-plan">{balances[conn.id].plan_type}</span>
+                        {/if}
+                        {#if balances[conn.id].billing_reset}
+                          <span class="conn-balance-reset">📅 Resets {balances[conn.id].billing_reset}</span>
+                        {/if}
+                      </div>
+                      <div class="conn-balance-windows">
+                        {#each balances[conn.id].rate_windows as win}
+                          <div class="conn-balance-window" class:exceeded={win.exceeded}>
+                            <span class="conn-balance-window-label">{winLabel(win.name)}</span>
+                            <div class="conn-balance-window-bar">
+                              <div class="conn-balance-window-fill" style="width: {win.cap > 0 ? Math.min(100, (win.used / win.cap) * 100) : 0}%"></div>
+                            </div>
+                            <span class="conn-balance-window-text">{Math.round(win.used)}/{Math.round(win.cap)}</span>
+                          </div>
+                        {/each}
+                      </div>
+                      {#if balances[conn.id].usage}
+                        <div class="conn-balance-usage">
+                          {balances[conn.id].usage.total_requests} req · {fmtTokens(balances[conn.id].usage.total_tokens)} tok · {balances[conn.id].usage.success_rate.toFixed(0)}% ok
+                        </div>
+                      {/if}
+                    </div>
+                  {/if}
                 {/each}
 
                 {#if matchedConns.length > visibleConns.length}
@@ -3434,6 +3478,8 @@
   }
   /* ── Balance detail strip (CommandCode structured data) ── */
   .conn-balance-detail {
+    flex-basis: 100%;
+    width: 100%;
     margin-top: 8px;
     padding: 8px 10px;
     background: var(--color-bg-1);

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	_ "github.com/mattn/go-sqlite3"
 )
@@ -83,6 +84,15 @@ func (d *DB) migrate() error {
 			key_label TEXT NOT NULL DEFAULT 'API Key',
 			category TEXT NOT NULL DEFAULT 'foundation',
 			is_builtin INTEGER DEFAULT 0,
+			chat_path TEXT NOT NULL DEFAULT '/v1/chat/completions',
+			models_path TEXT NOT NULL DEFAULT '/v1/models',
+			auth_header TEXT NOT NULL DEFAULT 'Authorization',
+			auth_prefix TEXT NOT NULL DEFAULT 'Bearer ',
+			extra_headers TEXT NOT NULL DEFAULT '{}',
+			models_capability TEXT NOT NULL DEFAULT 'unsupported',
+			usage_capability TEXT NOT NULL DEFAULT 'not_provided',
+			verification_status TEXT NOT NULL DEFAULT 'unverified',
+			verified_at TEXT NOT NULL DEFAULT '',
 			created_at TEXT DEFAULT (datetime('now', 'localtime')),
 			updated_at TEXT DEFAULT (datetime('now', 'localtime'))
 		)`,
@@ -221,6 +231,15 @@ func (d *DB) migrate() error {
 		`ALTER TABLE connections ADD COLUMN oauth_provider TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE connections ADD COLUMN pool_id TEXT NOT NULL DEFAULT ''`,
 		`CREATE INDEX IF NOT EXISTS idx_connections_pool_id ON connections(pool_id)`,
+		`ALTER TABLE provider_presets ADD COLUMN chat_path TEXT NOT NULL DEFAULT '/v1/chat/completions'`,
+		`ALTER TABLE provider_presets ADD COLUMN models_path TEXT NOT NULL DEFAULT '/v1/models'`,
+		`ALTER TABLE provider_presets ADD COLUMN auth_header TEXT NOT NULL DEFAULT 'Authorization'`,
+		`ALTER TABLE provider_presets ADD COLUMN auth_prefix TEXT NOT NULL DEFAULT 'Bearer '`,
+		`ALTER TABLE provider_presets ADD COLUMN extra_headers TEXT NOT NULL DEFAULT '{}'`,
+		`ALTER TABLE provider_presets ADD COLUMN models_capability TEXT NOT NULL DEFAULT 'unsupported'`,
+		`ALTER TABLE provider_presets ADD COLUMN usage_capability TEXT NOT NULL DEFAULT 'not_provided'`,
+		`ALTER TABLE provider_presets ADD COLUMN verification_status TEXT NOT NULL DEFAULT 'unverified'`,
+		`ALTER TABLE provider_presets ADD COLUMN verified_at TEXT NOT NULL DEFAULT ''`,
 		// P1: Experimental Provider Registry Persistence — stores lifecycle state,
 		// admission reports, validation evidence, and descriptor snapshots for the
 		// Experimental provider ecosystem. Credentials are NEVER stored (Invariant 3).
@@ -257,6 +276,24 @@ func (d *DB) migrate() error {
 		}
 	}
 
+	// Fail-closed postcondition for the provider_presets capability columns.
+	// The loop above swallows every ALTER error, so a partially-applied
+	// migration would otherwise let Open() succeed and only fail later, at
+	// runtime, on the first presets query. Verify the columns exist now so a
+	// broken migration is loud at startup instead of silent at request time.
+	for _, col := range []string{
+		"chat_path", "models_path", "auth_header", "auth_prefix", "extra_headers",
+		"models_capability", "usage_capability", "verification_status", "verified_at",
+	} {
+		ok, err := d.columnExists("provider_presets", col)
+		if err != nil {
+			return fmt.Errorf("verify provider_presets.%s: %w", col, err)
+		}
+		if !ok {
+			return fmt.Errorf("provider_presets is missing column %q after migration", col)
+		}
+	}
+
 	// One-time backfill: force any admin that existed BEFORE this security
 	// migration (notably the legacy admin/admin123 seed) to rotate its password.
 	// Guarded by a settings marker so it never re-flags an admin that has
@@ -267,6 +304,27 @@ func (d *DB) migrate() error {
 	}
 
 	return nil
+}
+
+// columnExists reports whether the named column is present on a table. It is
+// used as a fail-closed postcondition check after the (error-swallowing)
+// migration loop, so a partially applied schema is caught at startup.
+func (d *DB) columnExists(table, column string) (bool, error) {
+	rows, err := d.conn.Query(`SELECT name FROM pragma_table_info(?)`, table)
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return false, err
+		}
+		if strings.EqualFold(name, column) {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
 }
 
 // GetSetting retrieves a setting value by key

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1,9 +1,12 @@
 package db
 
 import (
+	"database/sql"
 	"os"
 	"path/filepath"
 	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
 )
 
 func TestOpenAndClose(t *testing.T) {
@@ -138,6 +141,55 @@ func TestOpen_DefaultMaxConns(t *testing.T) {
 	// If it opened without error with default conns, that's sufficient
 	// (go-sqlite3 doesn't expose MaxOpenConns getter)
 	_ = d.Conn().Ping()
+}
+
+func TestOpen_MigratesLegacyProviderPresetsWithCapabilityDefaults(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "legacy.db")
+	legacy, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("open legacy db: %v", err)
+	}
+	_, err = legacy.Exec(`CREATE TABLE provider_presets (
+		id TEXT PRIMARY KEY, name TEXT NOT NULL, domain TEXT NOT NULL,
+		base_url TEXT NOT NULL, format TEXT NOT NULL DEFAULT 'openai',
+		key_label TEXT NOT NULL DEFAULT 'API Key', category TEXT NOT NULL DEFAULT 'foundation',
+		is_builtin INTEGER DEFAULT 0, created_at TEXT, updated_at TEXT
+	);
+	INSERT INTO provider_presets (id,name,domain,base_url,is_builtin)
+	VALUES ('legacy','Legacy Custom','example.com','https://api.example.com/v1',0);`)
+	if err != nil {
+		t.Fatalf("create legacy schema: %v", err)
+	}
+	if err := legacy.Close(); err != nil {
+		t.Fatalf("close legacy db: %v", err)
+	}
+
+	d, err := Open(path)
+	if err != nil {
+		t.Fatalf("migrate legacy db: %v", err)
+	}
+	defer d.Close()
+
+	var chatPath, modelsPath, authHeader, authPrefix, extraHeaders string
+	var modelsCapability, usageCapability, verificationStatus, verifiedAt string
+	err = d.Conn().QueryRow(`SELECT chat_path, models_path, auth_header, auth_prefix,
+		extra_headers, models_capability, usage_capability, verification_status, verified_at
+		FROM provider_presets WHERE id='legacy'`).Scan(
+		&chatPath, &modelsPath, &authHeader, &authPrefix, &extraHeaders,
+		&modelsCapability, &usageCapability, &verificationStatus, &verifiedAt,
+	)
+	if err != nil {
+		t.Fatalf("read migrated preset metadata: %v", err)
+	}
+	if chatPath != "/v1/chat/completions" || modelsPath != "/v1/models" {
+		t.Errorf("paths = %q, %q; want generic OpenAI-compatible defaults", chatPath, modelsPath)
+	}
+	if authHeader != "Authorization" || authPrefix != "Bearer " || extraHeaders != "{}" {
+		t.Errorf("auth contract = %q, %q, %q; want Authorization/Bearer/{}", authHeader, authPrefix, extraHeaders)
+	}
+	if modelsCapability != "unsupported" || usageCapability != "not_provided" || verificationStatus != "unverified" || verifiedAt != "" {
+		t.Errorf("capabilities = %q, %q, %q, %q; want unsupported/not_provided/unverified/empty", modelsCapability, usageCapability, verificationStatus, verifiedAt)
+	}
 }
 
 func TestMain(m *testing.M) {

--- a/internal/discover/discover.go
+++ b/internal/discover/discover.go
@@ -255,7 +255,7 @@ func (d *Discoverer) fetchModelsFromProvider(conn map[string]any) ([]ModelInfo, 
 			authHeader = "Authorization"
 		}
 		authPrefix, _ := conn["auth_prefix"].(string)
-		if authPrefix == "" {
+		if authPrefix == "" && !strings.EqualFold(authHeader, "x-api-key") {
 			authPrefix = "Bearer "
 		}
 		req.Header.Set(authHeader, authPrefix+apiKey)

--- a/internal/provider/default_provider.go
+++ b/internal/provider/default_provider.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"strings"
 )
@@ -63,11 +64,19 @@ func (d *DefaultProvider) Prepare(ctx context.Context, req *Request, conn *ConnC
 		authHeader = "Authorization"
 	}
 	authPrefix := conn.AuthPrefix
-	if authPrefix == "" {
+	if authPrefix == "" && !strings.EqualFold(authHeader, "x-api-key") {
 		authPrefix = "Bearer "
 	}
 	if conn.APIKey != "" {
 		h.Set(authHeader, authPrefix+conn.APIKey)
+	}
+	if conn.ExtraHeaders != "" {
+		var extra map[string]string
+		if json.Unmarshal([]byte(conn.ExtraHeaders), &extra) == nil {
+			for name, value := range extra {
+				h.Set(name, value)
+			}
+		}
 	}
 
 	return &UpstreamRequest{

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -174,16 +174,16 @@ func TestDefaultProviderPrepareOpenAIShape(t *testing.T) {
 }
 
 func TestDefaultProviderPrepareFaithfulToLiveRouter(t *testing.T) {
-	// The live router (proxy.go:981-987) and the connection-insert path
-	// (handlers.go:205-206) BOTH treat an empty AuthPrefix as "Bearer ". The
-	// current system has no representation for "no prefix", so the provider
-	// mirrors that EXACTLY -- faithfulness, not a behavior change.
+	// The live router and the connection-insert path BOTH default an empty
+	// AuthPrefix to "Bearer " -- but ONLY for non-x-api-key headers. The
+	// x-api-key family has no prefix by contract (Anthropic), covered by
+	// TestDefaultProviderPrepareBareApiKeyToken below.
 	d := NewDefaultProvider("custom")
 	conn := &ConnConfig{
 		BaseURL:    "https://api.example.com",
 		APIKey:     "k",
 		ChatPath:   "/openai/v1/chat/completions",
-		AuthHeader: "X-Api-Key",
+		AuthHeader: "X-Custom-Token",
 		AuthPrefix: "",
 	}
 	req := &Request{Body: []byte(`{}`), Headers: http.Header{}}
@@ -194,8 +194,50 @@ func TestDefaultProviderPrepareFaithfulToLiveRouter(t *testing.T) {
 	if up.URL != "https://api.example.com/openai/v1/chat/completions" {
 		t.Fatalf("override chatPath not honored: %s", up.URL)
 	}
-	if got := up.Header.Get("X-Api-Key"); got != "Bearer k" {
+	if got := up.Header.Get("X-Custom-Token"); got != "Bearer k" {
 		t.Fatalf("expected live-faithful 'Bearer k' on custom header, got %q", got)
+	}
+}
+
+// TestDefaultProviderPrepareBareApiKeyToken pins the Anthropic contract: an
+// x-api-key header with an empty prefix sends the BARE key. Before this, the
+// empty-prefix default made the advertised Anthropic preset unsatisfiable.
+func TestDefaultProviderPrepareBareApiKeyToken(t *testing.T) {
+	d := NewDefaultProvider("anthropic")
+	conn := &ConnConfig{
+		BaseURL:    "https://api.anthropic.com/v1",
+		APIKey:     "sk-ant-123",
+		ChatPath:   "/messages",
+		AuthHeader: "x-api-key",
+		AuthPrefix: "",
+	}
+	up, err := d.Prepare(context.Background(), &Request{Body: []byte(`{}`)}, conn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := up.Header.Get("X-Api-Key"); got != "sk-ant-123" {
+		t.Fatalf("x-api-key must carry the bare token, got %q", got)
+	}
+}
+
+// TestDefaultProviderPrepareExtraHeaders pins that provider-required headers
+// survive Test AND real chat traffic: the same ConnConfig drives both paths.
+func TestDefaultProviderPrepareExtraHeaders(t *testing.T) {
+	d := NewDefaultProvider("anthropic")
+	conn := &ConnConfig{
+		BaseURL:      "https://api.anthropic.com/v1",
+		APIKey:       "sk-ant-123",
+		ChatPath:     "/messages",
+		AuthHeader:   "x-api-key",
+		AuthPrefix:   "",
+		ExtraHeaders: `{"anthropic-version":"2023-06-01"}`,
+	}
+	up, err := d.Prepare(context.Background(), &Request{Body: []byte(`{}`)}, conn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := up.Header.Get("anthropic-version"); got != "2023-06-01" {
+		t.Fatalf("extra_headers must be applied to the upstream request, got %q", got)
 	}
 }
 

--- a/internal/provider/types.go
+++ b/internal/provider/types.go
@@ -69,15 +69,16 @@ type Response struct {
 // commit — it is NOT coupled to the live Connection type, so importing this
 // package can never drag in or alter the DB layer.)
 type ConnConfig struct {
-	ID         string
-	Name       string
-	BaseURL    string
-	APIKey     string
-	Format     string // retained for the compat/fallback resolution path
-	ChatPath   string
-	AuthHeader string
-	AuthPrefix string
-	Priority   int
+	ID           string
+	Name         string
+	BaseURL      string
+	APIKey       string
+	Format       string // retained for the compat/fallback resolution path
+	ChatPath     string
+	AuthHeader   string
+	AuthPrefix   string
+	ExtraHeaders string
+	Priority     int
 }
 
 // Provider is the core contract. It captures exactly what the doUpstream

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -202,6 +202,11 @@ func (s *Server) handleCreateConnection(w http.ResponseWriter, r *http.Request) 
 		ModelsPath    string `json:"modelsPath"`
 		AuthHeader    string `json:"authHeader"`
 		AuthPrefix    string `json:"authPrefix"`
+		ChatPath2     string `json:"chat_path"`
+		ModelsPath2   string `json:"models_path"`
+		AuthHeader2   string `json:"auth_header"`
+		AuthPrefix2   string `json:"auth_prefix"`
+		ExtraHeaders  string `json:"extra_headers"`
 		OAuthProvider string `json:"oauth_provider"`
 		PoolID        string `json:"pool_id"`
 	}
@@ -216,6 +221,18 @@ func (s *Server) handleCreateConnection(w http.ResponseWriter, r *http.Request) 
 	}
 	if input.APIKey == "" {
 		input.APIKey = input.APIKey2
+	}
+	if input.ChatPath == "" {
+		input.ChatPath = input.ChatPath2
+	}
+	if input.ModelsPath == "" {
+		input.ModelsPath = input.ModelsPath2
+	}
+	if input.AuthHeader == "" {
+		input.AuthHeader = input.AuthHeader2
+	}
+	if input.AuthPrefix == "" {
+		input.AuthPrefix = input.AuthPrefix2
 	}
 	if input.Name == "" || input.BaseURL == "" {
 		http.Error(w, `{"error":{"message":"name and baseUrl are required"}}`, http.StatusBadRequest)
@@ -237,14 +254,14 @@ func (s *Server) handleCreateConnection(w http.ResponseWriter, r *http.Request) 
 	if input.AuthHeader == "" {
 		input.AuthHeader = "Authorization"
 	}
-	if input.AuthPrefix == "" {
+	if input.AuthPrefix == "" && !strings.EqualFold(input.AuthHeader, "x-api-key") {
 		input.AuthPrefix = "Bearer "
 	}
 
 	id := uuid.New().String()
 	_, err := s.db.Conn().Exec(
-		`INSERT INTO connections (id, name, base_url, api_key, oauth_provider, format, priority, chat_path, models_path, auth_header, auth_prefix, pool_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		id, input.Name, input.BaseURL, input.APIKey, strings.TrimSpace(strings.ToLower(input.OAuthProvider)), input.Format, input.Priority, input.ChatPath, input.ModelsPath, input.AuthHeader, input.AuthPrefix, strings.TrimSpace(input.PoolID),
+		`INSERT INTO connections (id, name, base_url, api_key, oauth_provider, format, priority, chat_path, models_path, auth_header, auth_prefix, extra_headers, pool_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		id, input.Name, input.BaseURL, input.APIKey, strings.TrimSpace(strings.ToLower(input.OAuthProvider)), input.Format, input.Priority, input.ChatPath, input.ModelsPath, input.AuthHeader, input.AuthPrefix, input.ExtraHeaders, strings.TrimSpace(input.PoolID),
 	)
 	if err != nil {
 		http.Error(w, `{"error":"failed to create connection"}`, http.StatusInternalServerError)

--- a/internal/server/handlers_balance.go
+++ b/internal/server/handlers_balance.go
@@ -12,10 +12,10 @@ import (
 
 // RateWindow represents a usage window (5h, weekly, daily, etc.)
 type RateWindow struct {
-	Name      string  `json:"name"`       // e.g., "5-hour", "weekly", "daily"
-	Used      float64 `json:"used"`       // Requests used in window
-	Cap       float64 `json:"cap"`        // Max requests in window
-	Exceeded  bool    `json:"exceeded"`   // Whether window limit was hit
+	Name     string  `json:"name"`     // e.g., "5-hour", "weekly", "daily"
+	Used     float64 `json:"used"`     // Requests used in window
+	Cap      float64 `json:"cap"`      // Max requests in window
+	Exceeded bool    `json:"exceeded"` // Whether window limit was hit
 }
 
 // UsageStats represents request-level usage statistics.
@@ -28,14 +28,14 @@ type UsageStats struct {
 
 // BalanceInfo represents the credit/usage information from a provider.
 type BalanceInfo struct {
-	Balance      string       `json:"balance"`       // Current balance (e.g., "$95.20" or "9520 credits")
-	TotalUsed    string       `json:"total_used"`    // Total amount used
-	Currency     string       `json:"currency"`      // USD, credits, etc.
-	PlanType     string       `json:"plan_type"`     // prepaid, subscription, free, etc.
-	RateInfo     string       `json:"rate_info"`     // Legacy: flat rate info string (for non-CC providers)
-	ProviderType string       `json:"provider_type"` // deepseek, openai, commandcode, etc.
-	UpdatedAt    string       `json:"updated_at"`    // When this info was fetched
-	Error        string       `json:"error,omitempty"` // Error message if fetch failed
+	Balance      string `json:"balance"`         // Current balance (e.g., "$95.20" or "9520 credits")
+	TotalUsed    string `json:"total_used"`      // Total amount used
+	Currency     string `json:"currency"`        // USD, credits, etc.
+	PlanType     string `json:"plan_type"`       // prepaid, subscription, free, etc.
+	RateInfo     string `json:"rate_info"`       // Legacy: flat rate info string (for non-CC providers)
+	ProviderType string `json:"provider_type"`   // deepseek, openai, commandcode, etc.
+	UpdatedAt    string `json:"updated_at"`      // When this info was fetched
+	Error        string `json:"error,omitempty"` // Error message if fetch failed
 
 	// Structured fields (populated for CommandCode, empty for others)
 	RateWindows  []RateWindow `json:"rate_windows,omitempty"`
@@ -119,10 +119,10 @@ func (s *Server) handleGetAllBalances(w http.ResponseWriter, r *http.Request) {
 	defer rows.Close()
 
 	type connInfo struct {
-		ID       string
-		BaseURL  string
-		APIKey   string
-		Format   string
+		ID        string
+		BaseURL   string
+		APIKey    string
+		Format    string
 		OAuthProv string
 	}
 	var conns []connInfo
@@ -192,6 +192,8 @@ func fetchProviderBalance(baseURL, apiKey, format string) BalanceInfo {
 	switch {
 	case strings.Contains(host, "commandcode"):
 		return fetchCommandCodeBalance(apiKey)
+	case strings.Contains(host, "openrouter"):
+		return fetchOpenRouterBalance(apiKey)
 	case strings.Contains(host, "deepseek"):
 		return fetchDeepseekBalance(apiKey)
 	case strings.Contains(host, "openai"):
@@ -346,6 +348,55 @@ func fetchCommandCodeBalance(apiKey string) BalanceInfo {
 	case <-time.After(7 * time.Second):
 		return BalanceInfo{ProviderType: "commandcode", Error: "timeout"}
 	}
+}
+
+func fetchOpenRouterBalance(apiKey string) BalanceInfo {
+	req, _ := http.NewRequest("GET", "https://openrouter.ai/api/v1/auth/key", nil)
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return BalanceInfo{ProviderType: "openrouter", Error: err.Error()}
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		return BalanceInfo{ProviderType: "openrouter", Error: fmt.Sprintf("HTTP %d: %s", resp.StatusCode, truncateStr(string(body), 200))}
+	}
+	return parseOpenRouterBalance(body)
+}
+
+// parseOpenRouterBalance decodes the /api/v1/auth/key response into a BalanceInfo.
+func parseOpenRouterBalance(body []byte) BalanceInfo {
+	var data struct {
+		Data struct {
+			Limit          float64 `json:"limit"`
+			LimitRemaining float64 `json:"limit_remaining"`
+			Usage          float64 `json:"usage"`
+			IsFreeTier     bool    `json:"is_free_tier"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &data); err != nil {
+		return BalanceInfo{ProviderType: "openrouter", Error: "parse error: " + err.Error()}
+	}
+
+	d := data.Data
+	info := BalanceInfo{ProviderType: "openrouter", PlanType: "api"}
+	if d.IsFreeTier {
+		info.PlanType = "free_tier"
+	}
+
+	// A $limit means the key is capped (e.g. free tier $2/day); $0 = no cap.
+	if d.Limit > 0 {
+		info.TotalUsed = fmt.Sprintf("$%.4f", d.Usage)
+		info.Currency = "USD"
+		info.RateInfo = fmt.Sprintf("Limit $%.2f remaining of $%.2f · $%.4f used", d.LimitRemaining, d.Limit, d.Usage)
+	} else {
+		info.RateInfo = fmt.Sprintf("Unlimited · $%.4f used", d.Usage)
+	}
+	return info
 }
 
 func fetchDeepseekBalance(apiKey string) BalanceInfo {

--- a/internal/server/handlers_balance.go
+++ b/internal/server/handlers_balance.go
@@ -194,6 +194,8 @@ func fetchProviderBalance(baseURL, apiKey, format string) BalanceInfo {
 		return fetchCommandCodeBalance(apiKey)
 	case strings.Contains(host, "openrouter"):
 		return fetchOpenRouterBalance(apiKey)
+	case strings.Contains(host, "kilo"):
+		return fetchKiloBalance(apiKey)
 	case strings.Contains(host, "deepseek"):
 		return fetchDeepseekBalance(apiKey)
 	case strings.Contains(host, "openai"):
@@ -395,6 +397,61 @@ func parseOpenRouterBalance(body []byte) BalanceInfo {
 		info.RateInfo = fmt.Sprintf("Limit $%.2f remaining of $%.2f · $%.4f used", d.LimitRemaining, d.Limit, d.Usage)
 	} else {
 		info.RateInfo = fmt.Sprintf("Unlimited · $%.4f used", d.Usage)
+	}
+	return info
+}
+
+// fetchKiloBalance reads the credit balance from Kilo's /api/user endpoint.
+// Kilo (a reseller/proxy) reports lifetime credit totals in microdollars
+// (1 USD = 1,000,000 µ$). Remaining = acquired − used.
+func fetchKiloBalance(apiKey string) BalanceInfo {
+	req, _ := http.NewRequest("GET", "https://api.kilo.ai/api/user", nil)
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return BalanceInfo{ProviderType: "kilo", Error: err.Error()}
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		return BalanceInfo{ProviderType: "kilo", Error: fmt.Sprintf("HTTP %d: %s", resp.StatusCode, truncateStr(string(body), 200))}
+	}
+	return parseKiloBalance(body)
+}
+
+// parseKiloBalance decodes Kilo's /api/user response into a BalanceInfo.
+func parseKiloBalance(body []byte) BalanceInfo {
+	var u struct {
+		MicrodollarsUsed     int64   `json:"microdollars_used"`
+		TotalMicrodollarsAcq int64   `json:"total_microdollars_acquired"`
+		NextCreditExpiration *string `json:"next_credit_expiration_at"`
+	}
+	if err := json.Unmarshal(body, &u); err != nil {
+		return BalanceInfo{ProviderType: "kilo", Error: "parse error: " + err.Error()}
+	}
+
+	used := float64(u.MicrodollarsUsed) / 1e6
+	acquired := float64(u.TotalMicrodollarsAcq) / 1e6
+	remaining := acquired - used
+	if remaining < 0 {
+		remaining = 0
+	}
+
+	info := BalanceInfo{
+		ProviderType: "kilo",
+		PlanType:     "credits",
+		Currency:     "USD",
+		Balance:      fmt.Sprintf("$%.2f", remaining),
+		TotalUsed:    fmt.Sprintf("$%.4f", used),
+		RateInfo:     fmt.Sprintf("Credit $%.2f remaining · $%.4f used", remaining, used),
+	}
+	if u.NextCreditExpiration != nil && *u.NextCreditExpiration != "" {
+		if t, err := time.Parse(time.RFC3339, *u.NextCreditExpiration); err == nil {
+			info.BillingReset = t.Format("Jan 2")
+		}
 	}
 	return info
 }

--- a/internal/server/handlers_balance_test.go
+++ b/internal/server/handlers_balance_test.go
@@ -1,0 +1,41 @@
+package server
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseOpenRouterBalanceFreeTierLimit(t *testing.T) {
+	body := []byte(`{"data":{"label":"sk-or-v1-xxx","limit":2,"limit_remaining":2,"usage":0.16057575,"is_free_tier":true}}`)
+	info := parseOpenRouterBalance(body)
+	if info.ProviderType != "openrouter" {
+		t.Errorf("provider_type = %q, want openrouter", info.ProviderType)
+	}
+	if info.PlanType != "free_tier" {
+		t.Errorf("plan_type = %q, want free_tier", info.PlanType)
+	}
+	if !strings.Contains(info.RateInfo, "remaining") {
+		t.Errorf("rate_info should mention remaining, got %q", info.RateInfo)
+	}
+	if info.Balance != "" {
+		t.Errorf("balance should be empty (rate badge path), got %q", info.Balance)
+	}
+}
+
+func TestParseOpenRouterBalanceUnlimited(t *testing.T) {
+	body := []byte(`{"data":{"limit":0,"limit_remaining":0,"usage":0.5,"is_free_tier":false}}`)
+	info := parseOpenRouterBalance(body)
+	if info.PlanType != "api" {
+		t.Errorf("plan_type = %q, want api", info.PlanType)
+	}
+	if !strings.Contains(info.RateInfo, "Unlimited") {
+		t.Errorf("rate_info should say Unlimited, got %q", info.RateInfo)
+	}
+}
+
+func TestParseOpenRouterBalanceMalformed(t *testing.T) {
+	info := parseOpenRouterBalance([]byte(`not json`))
+	if info.Error == "" {
+		t.Errorf("expected parse error")
+	}
+}

--- a/internal/server/handlers_balance_test.go
+++ b/internal/server/handlers_balance_test.go
@@ -39,3 +39,24 @@ func TestParseOpenRouterBalanceMalformed(t *testing.T) {
 		t.Errorf("expected parse error")
 	}
 }
+
+func TestParseKiloBalanceRemaining(t *testing.T) {
+	body := []byte(`{"microdollars_used":2500000,"total_microdollars_acquired":10000000}`)
+	info := parseKiloBalance(body)
+	if info.ProviderType != "kilo" {
+		t.Errorf("provider_type = %q, want kilo", info.ProviderType)
+	}
+	if info.Balance != "$7.50" {
+		t.Errorf("balance = %q, want $7.50", info.Balance)
+	}
+	if !strings.Contains(info.RateInfo, "remaining") {
+		t.Errorf("rate_info should mention remaining, got %q", info.RateInfo)
+	}
+}
+
+func TestParseKiloBalanceZero(t *testing.T) {
+	info := parseKiloBalance([]byte(`{"microdollars_used":0,"total_microdollars_acquired":0}`))
+	if info.Balance != "$0.00" {
+		t.Errorf("balance = %q, want $0.00", info.Balance)
+	}
+}

--- a/internal/server/handlers_parity.go
+++ b/internal/server/handlers_parity.go
@@ -233,9 +233,10 @@ func (s *Server) handlePresetTest(w http.ResponseWriter, r *http.Request){
     modelsPath,_:=preset["modelsPath"].(string)
     authHeader,_:=preset["authHeader"].(string)
     authPrefix,_:=preset["authPrefix"].(string)
+    extraHeaders,_:=preset["extraHeaders"].(string)
     apiKey,_:=in["apiKey"].(string)
     start:=time.Now()
-    models,_,_,err:=fetchModels(baseUrl,modelsPath,apiKey,authHeader,authPrefix)
+    models,_,_,err:=fetchModels(baseUrl,modelsPath,apiKey,authHeader,authPrefix,extraHeaders)
     if err!=nil{
         writeJSON(w,map[string]any{"success":false,"error":err.Error(),"latency_ms":time.Since(start).Milliseconds()})
         return
@@ -243,11 +244,17 @@ func (s *Server) handlePresetTest(w http.ResponseWriter, r *http.Request){
     writeJSON(w,map[string]any{"success":true,"message":fmt.Sprintf("Connected · %d models found · %dms",len(models),time.Since(start).Milliseconds()),"models_count":len(models),"latency_ms":time.Since(start).Milliseconds(),"models":models})
 }
 
-func fetchModels(base, path, key, h, prefix string)([]any,int,[]byte,error){
+func fetchModels(base, path, key, h, prefix, extraHeaders string)([]any,int,[]byte,error){
     if base=="" { return nil,0,nil,fmt.Errorf("base_url required") }
     url := provider.JoinUpstreamPath(base, path)
     req,_:=http.NewRequest("GET", url, nil)
     if key!=""{ if h==""{h="Authorization"}; req.Header.Set(h,prefix+key) }
+    if extraHeaders!="" {
+        var extra map[string]string
+        if json.Unmarshal([]byte(extraHeaders),&extra)==nil {
+            for name,value:=range extra { req.Header.Set(name,value) }
+        }
+    }
     c:=&http.Client{Timeout:20*time.Second}; resp,err:=c.Do(req); if err!=nil{return nil,0,nil,err}; defer resp.Body.Close()
     b,_:=io.ReadAll(resp.Body)
     if resp.StatusCode>=400 { return nil,resp.StatusCode,b,fmt.Errorf("upstream status %d",resp.StatusCode) }
@@ -321,9 +328,12 @@ func (s *Server) handleConnectionTest(w http.ResponseWriter, r *http.Request){
     oauthFromIn,_:=in["oauth_provider"].(string)
     if strings.TrimSpace(oauthFromIn)!="" { oauthProv=strings.TrimSpace(oauthFromIn) }
     path,_:=in["models_path"].(string); if path==""{path,_=in["modelsPath"].(string)}; if path==""{path="/v1/models"}
+    authHeader,_:=in["auth_header"].(string); if authHeader==""{authHeader="Authorization"}
+    authPrefix,_:=in["auth_prefix"].(string); if authPrefix=="" && !strings.EqualFold(authHeader,"x-api-key"){authPrefix="Bearer "}
+    extraHeaders,_:=in["extra_headers"].(string)
     // Connection metadata recovered from DB when only an id is supplied; used
     // to route format=commandcode (CC Alpha) tests through /alpha/generate.
-    var formatFromDB string
+    formatFromDB,_:=in["format"].(string)
     // If only an id was supplied (list-view Test button), look up the saved
     // connection from the DB so we can re-test it without re-typing the key.
     if base=="" {
@@ -388,7 +398,7 @@ func (s *Server) handleConnectionTest(w http.ResponseWriter, r *http.Request){
         return
     }
 
-    models,status,body,err:=fetchModels(base,path,key,"Authorization","Bearer ")
+    models,status,body,err:=fetchModels(base,path,key,authHeader,authPrefix,extraHeaders)
     latency:=time.Since(start).Milliseconds()
 
     if err==nil{
@@ -770,6 +780,7 @@ func (s *Server) handleModelsSyncByID(w http.ResponseWriter, r *http.Request) {
 
     res, err := s.discoverer.SyncConnection(connID)
     if err != nil {
+        w.WriteHeader(http.StatusBadGateway)
         writeJSON(w, map[string]any{"error": map[string]string{"message": err.Error()}})
         return
     }

--- a/internal/server/handlers_presets.go
+++ b/internal/server/handlers_presets.go
@@ -4,22 +4,54 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"strings"
 	"time"
 )
 
 // Preset represents a provider preset in the catalog
 type Preset struct {
-	ID        string `json:"id"`
-	Name      string `json:"name"`
-	Domain    string `json:"domain"`
-	BaseURL   string `json:"base_url"`
-	Format    string `json:"format"`
-	KeyLabel  string `json:"key_label"`
-	Category  string `json:"category"`
-	IsBuiltin int    `json:"is_builtin"`
-	CreatedAt string `json:"created_at"`
-	UpdatedAt string `json:"updated_at"`
+	ID                 string `json:"id"`
+	Name               string `json:"name"`
+	Domain             string `json:"domain"`
+	BaseURL            string `json:"base_url"`
+	Format             string `json:"format"`
+	KeyLabel           string `json:"key_label"`
+	Category           string `json:"category"`
+	IsBuiltin          int    `json:"is_builtin"`
+	ChatPath           string `json:"chat_path"`
+	ModelsPath         string `json:"models_path"`
+	AuthHeader         string `json:"auth_header"`
+	AuthPrefix         string `json:"auth_prefix"`
+	ExtraHeaders       string `json:"extra_headers"`
+	ModelsCapability   string `json:"models_capability"`
+	UsageCapability    string `json:"usage_capability"`
+	VerificationStatus string `json:"verification_status"`
+	VerifiedAt         string `json:"verified_at"`
+	CreatedAt          string `json:"created_at"`
+	UpdatedAt          string `json:"updated_at"`
+}
+
+// validatePresetExtraHeaders keeps this catalogue field non-secret. It is
+// returned by the presets API, so credentials belong in api_key/auth fields,
+// never here. String-only values also make discovery and proxy interpretation
+// deterministic.
+func validatePresetExtraHeaders(raw string) error {
+	if raw == "" {
+		return nil
+	}
+	var headers map[string]string
+	if err := json.Unmarshal([]byte(raw), &headers); err != nil {
+		return fmt.Errorf("extra_headers must be a JSON object with string values")
+	}
+	for name := range headers {
+		switch strings.ToLower(strings.TrimSpace(name)) {
+		case "authorization", "proxy-authorization", "x-api-key", "api-key", "cookie", "set-cookie":
+			return fmt.Errorf("extra_headers must not contain credential header %q", name)
+		}
+	}
+	return nil
 }
 
 // handleGetPresets returns all provider presets (built-in + custom)
@@ -30,8 +62,12 @@ func (s *Server) handleGetPresets(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rows, err := s.db.Conn().Query(`
-		SELECT id, name, domain, base_url, format, key_label, category, is_builtin, created_at, updated_at
+		SELECT id, name, domain, base_url, format, key_label, category, is_builtin,
+		       chat_path, models_path, auth_header, auth_prefix, extra_headers,
+		       models_capability, usage_capability, verification_status, verified_at,
+		       created_at, updated_at
 		FROM provider_presets
+		WHERE is_builtin = 0 OR (verification_status = 'verified' AND models_capability = 'supported')
 		ORDER BY is_builtin DESC, name ASC
 	`)
 	if err != nil {
@@ -43,7 +79,10 @@ func (s *Server) handleGetPresets(w http.ResponseWriter, r *http.Request) {
 	presets := []Preset{}
 	for rows.Next() {
 		var p Preset
-		if err := rows.Scan(&p.ID, &p.Name, &p.Domain, &p.BaseURL, &p.Format, &p.KeyLabel, &p.Category, &p.IsBuiltin, &p.CreatedAt, &p.UpdatedAt); err != nil {
+		if err := rows.Scan(&p.ID, &p.Name, &p.Domain, &p.BaseURL, &p.Format, &p.KeyLabel, &p.Category, &p.IsBuiltin,
+			&p.ChatPath, &p.ModelsPath, &p.AuthHeader, &p.AuthPrefix, &p.ExtraHeaders,
+			&p.ModelsCapability, &p.UsageCapability, &p.VerificationStatus, &p.VerifiedAt,
+			&p.CreatedAt, &p.UpdatedAt); err != nil {
 			continue
 		}
 		presets = append(presets, p)
@@ -60,12 +99,17 @@ func (s *Server) handleCreatePreset(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req struct {
-		Name     string `json:"name"`
-		Domain   string `json:"domain"`
-		BaseURL  string `json:"base_url"`
-		Format   string `json:"format"`
-		KeyLabel string `json:"key_label"`
-		Category string `json:"category"`
+		Name         string `json:"name"`
+		Domain       string `json:"domain"`
+		BaseURL      string `json:"base_url"`
+		Format       string `json:"format"`
+		KeyLabel     string `json:"key_label"`
+		Category     string `json:"category"`
+		ChatPath     string `json:"chat_path"`
+		ModelsPath   string `json:"models_path"`
+		AuthHeader   string `json:"auth_header"`
+		AuthPrefix   string `json:"auth_prefix"`
+		ExtraHeaders string `json:"extra_headers"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "invalid request body", http.StatusBadRequest)
@@ -85,30 +129,47 @@ func (s *Server) handleCreatePreset(w http.ResponseWriter, r *http.Request) {
 	if req.Category == "" {
 		req.Category = "foundation"
 	}
+	defaultChat, defaultModels := apiPathsFor(req.BaseURL)
+	if req.ChatPath == "" {
+		req.ChatPath = defaultChat
+	}
+	if req.ModelsPath == "" {
+		req.ModelsPath = defaultModels
+	}
+	if req.AuthHeader == "" {
+		req.AuthHeader = "Authorization"
+	}
+	if req.AuthPrefix == "" && !strings.EqualFold(req.AuthHeader, "x-api-key") {
+		req.AuthPrefix = "Bearer "
+	}
+	if req.ExtraHeaders == "" {
+		req.ExtraHeaders = "{}"
+	}
+	if err := validatePresetExtraHeaders(req.ExtraHeaders); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 
 	id, _ := generatePresetID()
 	now := time.Now().UTC().Format("2006-01-02 15:04:05")
 
 	_, err := s.db.Conn().Exec(`
-		INSERT INTO provider_presets (id, name, domain, base_url, format, key_label, category, is_builtin, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?, ?)
-	`, id, req.Name, req.Domain, req.BaseURL, req.Format, req.KeyLabel, req.Category, now, now)
+		INSERT INTO provider_presets (id,name,domain,base_url,format,key_label,category,is_builtin,chat_path,models_path,auth_header,auth_prefix,extra_headers,models_capability,usage_capability,verification_status,verified_at,created_at,updated_at)
+		VALUES (?,?,?,?,?,?,?,0,?,?,?,?,?,'unsupported','not_provided','unverified','',?,?)
+	`, id, req.Name, req.Domain, req.BaseURL, req.Format, req.KeyLabel, req.Category,
+		req.ChatPath, req.ModelsPath, req.AuthHeader, req.AuthPrefix, req.ExtraHeaders, now, now)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	writeData(w, Preset{
-		ID:        id,
-		Name:      req.Name,
-		Domain:    req.Domain,
-		BaseURL:   req.BaseURL,
-		Format:    req.Format,
-		KeyLabel:  req.KeyLabel,
-		Category:  req.Category,
-		IsBuiltin: 0,
-		CreatedAt: now,
-		UpdatedAt: now,
+		ID: id, Name: req.Name, Domain: req.Domain, BaseURL: req.BaseURL,
+		Format: req.Format, KeyLabel: req.KeyLabel, Category: req.Category, IsBuiltin: 0,
+		ChatPath: req.ChatPath, ModelsPath: req.ModelsPath, AuthHeader: req.AuthHeader,
+		AuthPrefix: req.AuthPrefix, ExtraHeaders: req.ExtraHeaders,
+		ModelsCapability: "unsupported", UsageCapability: "not_provided", VerificationStatus: "unverified",
+		CreatedAt: now, UpdatedAt: now,
 	})
 }
 
@@ -126,12 +187,17 @@ func (s *Server) handleUpdatePreset(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req struct {
-		Name     string `json:"name"`
-		Domain   string `json:"domain"`
-		BaseURL  string `json:"base_url"`
-		Format   string `json:"format"`
-		KeyLabel string `json:"key_label"`
-		Category string `json:"category"`
+		Name         string `json:"name"`
+		Domain       string `json:"domain"`
+		BaseURL      string `json:"base_url"`
+		Format       string `json:"format"`
+		KeyLabel     string `json:"key_label"`
+		Category     string `json:"category"`
+		ChatPath     string `json:"chat_path"`
+		ModelsPath   string `json:"models_path"`
+		AuthHeader   string `json:"auth_header"`
+		AuthPrefix   string `json:"auth_prefix"`
+		ExtraHeaders string `json:"extra_headers"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "invalid request body", http.StatusBadRequest)
@@ -150,12 +216,39 @@ func (s *Server) handleUpdatePreset(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Re-derive endpoint metadata when the base URL moved and the caller did
+	// not supply explicit paths: a versioned endpoint needs /v1/models while an
+	// unversioned one needs /models, so keeping the old value would silently
+	// point Get Models at a 404.
+	if req.ChatPath == "" || req.ModelsPath == "" {
+		dc, dm := apiPathsFor(req.BaseURL)
+		if req.ChatPath == "" {
+			req.ChatPath = dc
+		}
+		if req.ModelsPath == "" {
+			req.ModelsPath = dm
+		}
+	}
+	if req.AuthHeader == "" {
+		req.AuthHeader = "Authorization"
+	}
+	if req.ExtraHeaders == "" {
+		req.ExtraHeaders = "{}"
+	}
+	if err := validatePresetExtraHeaders(req.ExtraHeaders); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
 	now := time.Now().UTC().Format("2006-01-02 15:04:05")
 	_, err = s.db.Conn().Exec(`
 		UPDATE provider_presets
-		SET name = ?, domain = ?, base_url = ?, format = ?, key_label = ?, category = ?, updated_at = ?
+		SET name = ?, domain = ?, base_url = ?, format = ?, key_label = ?, category = ?,
+		    chat_path = ?, models_path = ?, auth_header = ?, auth_prefix = ?, extra_headers = ?,
+		    updated_at = ?
 		WHERE id = ?
-	`, req.Name, req.Domain, req.BaseURL, req.Format, req.KeyLabel, req.Category, now, id)
+	`, req.Name, req.Domain, req.BaseURL, req.Format, req.KeyLabel, req.Category,
+		req.ChatPath, req.ModelsPath, req.AuthHeader, req.AuthPrefix, req.ExtraHeaders, now, id)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -201,7 +294,7 @@ func (s *Server) handleDeletePreset(w http.ResponseWriter, r *http.Request) {
 // seedCatalogue is the list of built-in provider presets. It lives in its own
 // function so tests can assert on the catalogue without needing a database.
 func seedCatalogue() []Preset {
-	return []Preset{
+	presets := []Preset{
 		{Name: "OpenAI", Domain: "openai.com", BaseURL: "https://api.openai.com/v1", Format: "openai", KeyLabel: "API Key", Category: "foundation"},
 		{Name: "Anthropic", Domain: "anthropic.com", BaseURL: "https://api.anthropic.com/v1", Format: "anthropic", KeyLabel: "API Key", Category: "foundation"},
 		{Name: "Google AI", Domain: "ai.google.dev", BaseURL: "https://generativelanguage.googleapis.com/v1beta", Format: "gemini", KeyLabel: "API Key", Category: "foundation"},
@@ -283,6 +376,38 @@ func seedCatalogue() []Preset {
 		{Name: "Baseten", Domain: "baseten.co", BaseURL: "https://inference.baseten.co/v1", Format: "openai", KeyLabel: "API Key", Category: "inference"},
 		{Name: "Novita AI", Domain: "novita.ai", BaseURL: "https://api.novita.ai/v3/openai", Format: "openai", KeyLabel: "API Key", Category: "inference"},
 	}
+	verified := map[string]string{
+		"OpenAI": "rate_limits", "Anthropic": "not_provided", "Google AI": "not_provided",
+		"xAI": "rate_limits", "Mistral": "not_provided", "DeepSeek": "full", "Qwen": "not_provided",
+		"Moonshot": "not_provided", "Zhipu": "not_provided", "Groq": "rate_limits",
+		"Together": "not_provided", "Fireworks": "not_provided", "OpenRouter": "full",
+		"Perplexity": "not_provided", "Ollama": "not_provided", "Xiaomi MiMo": "not_provided",
+		"NVIDIA": "rate_limits", "Cerebras": "rate_limits", "Kilo Gateway": "full",
+		"TokenRouter": "not_provided", "SambaNova": "not_provided", "SiliconFlow": "not_provided",
+		"DeepInfra": "not_provided", "Jina AI": "not_provided", "Baseten": "not_provided", "Novita AI": "not_provided",
+	}
+	for i := range presets {
+		p := &presets[i]
+		p.ChatPath, p.ModelsPath = apiPathsFor(p.BaseURL)
+		p.AuthHeader, p.AuthPrefix, p.ExtraHeaders = "Authorization", "Bearer ", "{}"
+		p.ModelsCapability, p.UsageCapability, p.VerificationStatus = "unsupported", "not_provided", "unverified"
+		if usage, ok := verified[p.Name]; ok {
+			p.ModelsCapability, p.UsageCapability, p.VerificationStatus, p.VerifiedAt = "supported", usage, "verified", "2026-09-11"
+		}
+	}
+	for i := range presets {
+		p := &presets[i]
+		switch p.Name {
+		case "Anthropic":
+			p.ChatPath, p.ModelsPath, p.AuthHeader, p.AuthPrefix = "/messages", "/models", "x-api-key", ""
+			p.ExtraHeaders = `{"anthropic-version":"2023-06-01"}`
+		case "Google AI":
+			p.BaseURL, p.Format, p.ChatPath, p.ModelsPath = "https://generativelanguage.googleapis.com/v1beta/openai", "openai", "/chat/completions", "/models"
+		}
+	}
+	// CommandCode Alpha has a provider-specific model catalogue and usage API.
+	presets = append(presets, Preset{Name: "CommandCode Alpha", Domain: "commandcode.ai", BaseURL: "https://api.commandcode.ai", Format: "commandcode", KeyLabel: "Token", Category: "aggregator", ChatPath: "/alpha/generate", ModelsPath: "/provider/v1/models", AuthHeader: "Authorization", AuthPrefix: "Bearer ", ExtraHeaders: `{"x-cli-environment":"cli","x-cli-version":"0.26.25"}`, ModelsCapability: "supported", UsageCapability: "full", VerificationStatus: "verified", VerifiedAt: "2026-09-11"})
+	return presets
 }
 
 // handleSeedBuiltinPresets inserts missing built-in presets AND refreshes the
@@ -318,40 +443,64 @@ func (s *Server) handleSeedBuiltinPresets(w http.ResponseWriter, r *http.Request
 	updated := 0
 	skipped := 0
 	for _, p := range builtins {
-		// Find the existing row, preferring the current name, then a prior
-		// name, then the endpoint. base_url is the stable identity.
+		// Find the existing row in two steps so the two match kinds can have
+		// DIFFERENT update rules:
+		//   1. by name (current, then a prior name) — name is the real
+		//      identity, so base_url MAY be rewritten. Providers do move
+		//      endpoints (Google moved Gemini to the OpenAI-compatible
+		//      /v1beta/openai surface); without this, an existing install
+		//      would keep the stale URL forever while receiving the new
+		//      chat/models paths.
+		//   2. by endpoint — here base_url IS the identity we matched on, so
+		//      it must never be rewritten (it would collapse rows).
 		var id string
 		var isBuiltin int
-		row := s.db.Conn().QueryRow(
+		matchedByName := false
+		if err := s.db.Conn().QueryRow(
 			`SELECT id, is_builtin FROM provider_presets
-			   WHERE lower(name) = lower(?)
-			      OR lower(name) = lower(?)
-			      OR lower(rtrim(base_url, '/')) = lower(rtrim(?, '/'))
+			   WHERE lower(name) = lower(?) OR lower(name) = lower(?)
 			   LIMIT 1`,
-			p.Name, oldNameFor(renames, p.Name), p.BaseURL,
-		)
-		if err := row.Scan(&id, &isBuiltin); err == nil && id != "" {
+			p.Name, oldNameFor(renames, p.Name),
+		).Scan(&id, &isBuiltin); err != nil {
+			id = ""
+		}
+		if id != "" {
+			matchedByName = true
+		} else if err := s.db.Conn().QueryRow(
+			`SELECT id, is_builtin FROM provider_presets
+			   WHERE lower(rtrim(base_url, '/')) = lower(rtrim(?, '/'))
+			   LIMIT 1`,
+			p.BaseURL,
+		).Scan(&id, &isBuiltin); err != nil {
+			id = ""
+		}
+		if id != "" {
 			if isBuiltin == 1 {
-				// Refresh a built-in in place: name and category only. Never
-				// the base_url — that is the identity we matched on — and
-				// never a manual preset.
-				if _, err := s.db.Conn().Exec(
-					`UPDATE provider_presets SET name = ?, category = ?, updated_at = ? WHERE id = ? AND is_builtin = 1`,
-					p.Name, p.Category, now, id,
+				// Refresh a built-in in place. A manual preset is never touched.
+				if matchedByName {
+					if _, err := s.db.Conn().Exec(
+						`UPDATE provider_presets SET name=?, domain=?, base_url=?, format=?, key_label=?, category=?, chat_path=?, models_path=?, auth_header=?, auth_prefix=?, extra_headers=?, models_capability=?, usage_capability=?, verification_status=?, verified_at=?, updated_at=? WHERE id=? AND is_builtin=1`,
+						p.Name, p.Domain, p.BaseURL, p.Format, p.KeyLabel, p.Category, p.ChatPath, p.ModelsPath, p.AuthHeader, p.AuthPrefix, p.ExtraHeaders, p.ModelsCapability, p.UsageCapability, p.VerificationStatus, p.VerifiedAt, now, id,
+					); err == nil {
+						updated++
+					}
+				} else if _, err := s.db.Conn().Exec(
+					`UPDATE provider_presets SET name=?, domain=?, format=?, key_label=?, category=?, chat_path=?, models_path=?, auth_header=?, auth_prefix=?, extra_headers=?, models_capability=?, usage_capability=?, verification_status=?, verified_at=?, updated_at=? WHERE id=? AND is_builtin=1`,
+					p.Name, p.Domain, p.Format, p.KeyLabel, p.Category, p.ChatPath, p.ModelsPath, p.AuthHeader, p.AuthPrefix, p.ExtraHeaders, p.ModelsCapability, p.UsageCapability, p.VerificationStatus, p.VerifiedAt, now, id,
 				); err == nil {
 					updated++
 				}
 			} else {
-				skipped++ // manual preset shares the endpoint; leave it alone
+				skipped++ // manual preset shares the name or endpoint; leave it alone
 			}
 			continue
 		}
 
 		newID, _ := generatePresetID()
 		_, err := s.db.Conn().Exec(`
-			INSERT INTO provider_presets (id, name, domain, base_url, format, key_label, category, is_builtin, created_at, updated_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?)
-		`, newID, p.Name, p.Domain, p.BaseURL, p.Format, p.KeyLabel, p.Category, now, now)
+			INSERT INTO provider_presets (id,name,domain,base_url,format,key_label,category,is_builtin,chat_path,models_path,auth_header,auth_prefix,extra_headers,models_capability,usage_capability,verification_status,verified_at,created_at,updated_at)
+			VALUES (?,?,?,?,?,?,?,1,?,?,?,?,?,?,?,?,?,?,?)
+		`, newID, p.Name, p.Domain, p.BaseURL, p.Format, p.KeyLabel, p.Category, p.ChatPath, p.ModelsPath, p.AuthHeader, p.AuthPrefix, p.ExtraHeaders, p.ModelsCapability, p.UsageCapability, p.VerificationStatus, p.VerifiedAt, now, now)
 		if err == nil {
 			inserted++
 		}

--- a/internal/server/handlers_presets_catalogue_test.go
+++ b/internal/server/handlers_presets_catalogue_test.go
@@ -40,6 +40,44 @@ func TestBuiltinPresetsAreComplete(t *testing.T) {
 		if !strings.HasPrefix(p.BaseURL, "http://") && !strings.HasPrefix(p.BaseURL, "https://") {
 			t.Errorf("preset %q base URL %q is not an http(s) URL", p.Name, p.BaseURL)
 		}
+		if p.UsageCapability != "full" && p.UsageCapability != "rate_limits" && p.UsageCapability != "not_provided" {
+			t.Errorf("curated preset %q has invalid usage capability %q", p.Name, p.UsageCapability)
+		}
+		if p.VerificationStatus == "verified" && (p.ModelsCapability != "supported" || strings.TrimSpace(p.ModelsPath) == "" || strings.TrimSpace(p.VerifiedAt) == "") {
+			t.Errorf("verified preset %q lacks model/evidence metadata: %+v", p.Name, p)
+		}
+	}
+}
+
+func TestCatalogueHasConservativeVerifiedCohort(t *testing.T) {
+	verified := 0
+	for _, p := range builtinPresetCatalogue(t) {
+		if p.VerificationStatus == "verified" {
+			verified++
+		}
+	}
+	if verified < 10 || verified >= len(builtinPresetCatalogue(t)) {
+		t.Fatalf("verified cohort=%d total=%d; want a useful curated subset, not an empty or claim-all catalogue", verified, len(builtinPresetCatalogue(t)))
+	}
+}
+
+func TestProviderSpecificPresetContracts(t *testing.T) {
+	byName := map[string]Preset{}
+	for _, p := range builtinPresetCatalogue(t) {
+		byName[p.Name] = p
+	}
+
+	anthropic := byName["Anthropic"]
+	if anthropic.AuthHeader != "x-api-key" || anthropic.AuthPrefix != "" || anthropic.ModelsPath != "/models" || !strings.Contains(anthropic.ExtraHeaders, "anthropic-version") {
+		t.Errorf("Anthropic contract incorrect: %+v", anthropic)
+	}
+	google := byName["Google AI"]
+	if google.Format != "openai" || google.ModelsPath != "/models" || !strings.Contains(google.BaseURL, "/openai") {
+		t.Errorf("Google AI must use its OpenAI-compatible surface: %+v", google)
+	}
+	cc := byName["CommandCode Alpha"]
+	if cc.ChatPath != "/alpha/generate" || cc.ModelsPath != "/provider/v1/models" || cc.UsageCapability != "full" {
+		t.Errorf("CommandCode Alpha contract incorrect: %+v", cc)
 	}
 }
 

--- a/internal/server/handlers_presets_refresh_test.go
+++ b/internal/server/handlers_presets_refresh_test.go
@@ -42,14 +42,45 @@ func TestSeedBuiltinPresets_RefreshesExistingBuiltin(t *testing.T) {
 	if count != 1 {
 		t.Errorf("expected 1 row for %s after refresh, got %d (rename duplicated the row)", target.BaseURL, count)
 	}
-	var name, category string
+	var name, category, modelsPath, usageCapability, verificationStatus string
 	_ = s.db.Conn().QueryRow(
-		"SELECT name, category FROM provider_presets WHERE base_url = ?", target.BaseURL).Scan(&name, &category)
+		"SELECT name, category, models_path, usage_capability, verification_status FROM provider_presets WHERE base_url = ?", target.BaseURL).Scan(&name, &category, &modelsPath, &usageCapability, &verificationStatus)
 	if name != target.Name {
 		t.Errorf("name = %q, want refreshed %q", name, target.Name)
 	}
 	if category != target.Category {
 		t.Errorf("category = %q, want refreshed %q", category, target.Category)
+	}
+	if modelsPath != target.ModelsPath || usageCapability != target.UsageCapability || verificationStatus != "verified" {
+		t.Errorf("metadata not refreshed: models=%q usage=%q verification=%q", modelsPath, usageCapability, verificationStatus)
+	}
+}
+
+// Google moved from the native Gemini base to its OpenAI-compatible surface.
+// Name-matched built-ins must migrate the base URL as well as the paths;
+// otherwise an existing install ends up with a mixed, invalid contract.
+func TestSeedBuiltinPresets_MigratesGoogleBaseURLByName(t *testing.T) {
+	s := newRESTTestServer(t)
+	now := "2026-01-01 00:00:00"
+	_, err := s.db.Conn().Exec(`
+		INSERT INTO provider_presets (id,name,domain,base_url,format,key_label,category,is_builtin,created_at,updated_at)
+		VALUES ('google-old','Google AI','ai.google.dev','https://generativelanguage.googleapis.com/v1beta','gemini','API Key','foundation',1,?,?)`, now, now)
+	if err != nil {
+		t.Fatalf("seed old google row: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	s.handleSeedBuiltinPresets(rec, httptest.NewRequest("POST", "/api/presets/seed", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("seed: got %d (%s)", rec.Code, rec.Body.String())
+	}
+
+	var baseURL, format, chatPath, modelsPath string
+	if err := s.db.Conn().QueryRow(`SELECT base_url,format,chat_path,models_path FROM provider_presets WHERE id='google-old'`).Scan(&baseURL, &format, &chatPath, &modelsPath); err != nil {
+		t.Fatal(err)
+	}
+	if baseURL != "https://generativelanguage.googleapis.com/v1beta/openai" || format != "openai" || chatPath != "/chat/completions" || modelsPath != "/models" {
+		t.Fatalf("Google mixed contract after migration: base=%q format=%q chat=%q models=%q", baseURL, format, chatPath, modelsPath)
 	}
 }
 

--- a/internal/server/provider_bootstrap.go
+++ b/internal/server/provider_bootstrap.go
@@ -121,15 +121,16 @@ func (p *ProxyHandler) providerSDKEligible(conn *Connection) bool {
 // reads, so the SDK is backward compatible by construction (no schema change).
 func connToConfig(conn *Connection) *provider.ConnConfig {
 	return &provider.ConnConfig{
-		ID:         conn.ID,
-		Name:       conn.Name,
-		BaseURL:    conn.BaseURL,
-		APIKey:     conn.APIKey,
-		Format:     conn.Format,
-		ChatPath:   conn.ChatPath,
-		AuthHeader: conn.AuthHeader,
-		AuthPrefix: conn.AuthPrefix,
-		Priority:   conn.Priority,
+		ID:           conn.ID,
+		Name:         conn.Name,
+		BaseURL:      conn.BaseURL,
+		APIKey:       conn.APIKey,
+		Format:       conn.Format,
+		ChatPath:     conn.ChatPath,
+		AuthHeader:   conn.AuthHeader,
+		AuthPrefix:   conn.AuthPrefix,
+		ExtraHeaders: conn.ExtraHeaders,
+		Priority:     conn.Priority,
 	}
 }
 

--- a/internal/server/proxy.go
+++ b/internal/server/proxy.go
@@ -241,6 +241,7 @@ type Connection struct {
 	ChatPath      string `json:"chat_path"`
 	AuthHeader    string `json:"auth_header"`
 	AuthPrefix    string `json:"auth_prefix"`
+	ExtraHeaders  string `json:"extra_headers"`
 	IsActive      int    `json:"is_active"`
 	Priority      int    `json:"priority"`
 }
@@ -1153,14 +1154,14 @@ func (p *ProxyHandler) HandleChatCompletions(w http.ResponseWriter, r *http.Requ
 
 func (p *ProxyHandler) findConnectionByID(id string) (*Connection, error) {
 	row := p.db.Conn().QueryRow(`
-		SELECT id, name, base_url, api_key, COALESCE(oauth_provider,''), format, chat_path, auth_header, auth_prefix, is_active, priority, COALESCE(pool_id,'')
+		SELECT id, name, base_url, api_key, COALESCE(oauth_provider,''), format, chat_path, auth_header, auth_prefix, COALESCE(extra_headers,'{}'), is_active, priority, COALESCE(pool_id,'')
 		FROM connections
 		WHERE id = ? AND is_active = 1
 		LIMIT 1
 	`, id)
 
 	var conn Connection
-	err := row.Scan(&conn.ID, &conn.Name, &conn.BaseURL, &conn.APIKey, &conn.OAuthProvider, &conn.Format, &conn.ChatPath, &conn.AuthHeader, &conn.AuthPrefix, &conn.IsActive, &conn.Priority, &conn.PoolID)
+	err := row.Scan(&conn.ID, &conn.Name, &conn.BaseURL, &conn.APIKey, &conn.OAuthProvider, &conn.Format, &conn.ChatPath, &conn.AuthHeader, &conn.AuthPrefix, &conn.ExtraHeaders, &conn.IsActive, &conn.Priority, &conn.PoolID)
 	if err != nil {
 		return nil, fmt.Errorf("connection not found: %s", id)
 	}
@@ -1216,11 +1217,19 @@ func (p *ProxyHandler) doUpstream(r *http.Request, conn *Connection, body []byte
 		authHeader = "Authorization"
 	}
 	authPrefix := conn.AuthPrefix
-	if authPrefix == "" {
+	if authPrefix == "" && !strings.EqualFold(authHeader, "x-api-key") {
 		authPrefix = "Bearer "
 	}
 	if conn.APIKey != "" {
 		upReq.Header.Set(authHeader, authPrefix+conn.APIKey)
+	}
+	if conn.ExtraHeaders != "" {
+		var extra map[string]string
+		if json.Unmarshal([]byte(conn.ExtraHeaders), &extra) == nil {
+			for name, value := range extra {
+				upReq.Header.Set(name, value)
+			}
+		}
 	}
 	if xcc := r.Header.Get("X-Command-Code-Version"); xcc != "" {
 		upReq.Header.Set("X-Command-Code-Version", xcc)
@@ -1749,7 +1758,7 @@ func (p *ProxyHandler) resolveTieredCombo() ([]*Connection, string, bool) {
 func (p *ProxyHandler) buildAutoProviders() ([]combo.Provider, map[string]*Connection, map[string]string) {
 	rows, err := p.db.Conn().Query(`
 		SELECT c.id, c.name, c.base_url, c.api_key, COALESCE(c.oauth_provider,''), c.format, c.chat_path,
-		       c.auth_header, c.auth_prefix, c.is_active, c.priority,
+		       c.auth_header, c.auth_prefix, COALESCE(c.extra_headers,'{}'), c.is_active, c.priority,
 		       (SELECT m.model_id FROM discovered_models m
 		         WHERE m.connection_id = c.id AND m.is_active = 1
 		         ORDER BY m.model_id LIMIT 1) AS model_id
@@ -1772,7 +1781,7 @@ func (p *ProxyHandler) buildAutoProviders() ([]combo.Provider, map[string]*Conne
 		var c Connection
 		var modelID sql.NullString
 		if rows.Scan(&c.ID, &c.Name, &c.BaseURL, &c.APIKey, &c.OAuthProvider, &c.Format, &c.ChatPath,
-			&c.AuthHeader, &c.AuthPrefix, &c.IsActive, &c.Priority, &modelID) != nil {
+			&c.AuthHeader, &c.AuthPrefix, &c.ExtraHeaders, &c.IsActive, &c.Priority, &modelID) != nil {
 			continue
 		}
 		p.applyConnectionAuth(&c)
@@ -1926,7 +1935,7 @@ func stringSlice(v any) []string {
 }
 
 func (p *ProxyHandler) connectionsForModelAndIDs(model string, ids []string) []*Connection {
-	query := `SELECT c.id, c.name, c.base_url, c.api_key, COALESCE(c.oauth_provider,''), c.format, c.chat_path, c.auth_header, c.auth_prefix, c.is_active, c.priority FROM discovered_models m JOIN connections c ON m.connection_id=c.id WHERE m.model_id=? AND m.is_active=1 AND c.is_active=1`
+	query := `SELECT c.id, c.name, c.base_url, c.api_key, COALESCE(c.oauth_provider,''), c.format, c.chat_path, c.auth_header, c.auth_prefix, COALESCE(c.extra_headers,'{}'), c.is_active, c.priority FROM discovered_models m JOIN connections c ON m.connection_id=c.id WHERE m.model_id=? AND m.is_active=1 AND c.is_active=1`
 	args := []any{model}
 	if len(ids) > 0 {
 		ph := make([]string, len(ids))
@@ -1945,7 +1954,7 @@ func (p *ProxyHandler) connectionsForModelAndIDs(model string, ids []string) []*
 	var out []*Connection
 	for rows.Next() {
 		var c Connection
-		if rows.Scan(&c.ID, &c.Name, &c.BaseURL, &c.APIKey, &c.OAuthProvider, &c.Format, &c.ChatPath, &c.AuthHeader, &c.AuthPrefix, &c.IsActive, &c.Priority) == nil {
+		if rows.Scan(&c.ID, &c.Name, &c.BaseURL, &c.APIKey, &c.OAuthProvider, &c.Format, &c.ChatPath, &c.AuthHeader, &c.AuthPrefix, &c.ExtraHeaders, &c.IsActive, &c.Priority) == nil {
 			p.applyConnectionAuth(&c)
 			out = append(out, &c)
 		}
@@ -1955,7 +1964,7 @@ func (p *ProxyHandler) connectionsForModelAndIDs(model string, ids []string) []*
 
 func (p *ProxyHandler) findConnectionForModel(model string) (*Connection, error) {
 	row := p.db.Conn().QueryRow(`
-		SELECT c.id, c.name, c.base_url, c.api_key, COALESCE(c.oauth_provider,''), c.format, c.chat_path, c.auth_header, c.auth_prefix, c.is_active, c.priority, COALESCE(c.pool_id,'')
+		SELECT c.id, c.name, c.base_url, c.api_key, COALESCE(c.oauth_provider,''), c.format, c.chat_path, c.auth_header, c.auth_prefix, COALESCE(c.extra_headers,'{}'), c.is_active, c.priority, COALESCE(c.pool_id,'')
 		FROM discovered_models m
 		JOIN connections c ON m.connection_id = c.id
 		WHERE m.model_id = ? AND m.is_active = 1 AND c.is_active = 1
@@ -1964,7 +1973,7 @@ func (p *ProxyHandler) findConnectionForModel(model string) (*Connection, error)
 	`, model)
 
 	var conn Connection
-	err := row.Scan(&conn.ID, &conn.Name, &conn.BaseURL, &conn.APIKey, &conn.OAuthProvider, &conn.Format, &conn.ChatPath, &conn.AuthHeader, &conn.AuthPrefix, &conn.IsActive, &conn.Priority, &conn.PoolID)
+	err := row.Scan(&conn.ID, &conn.Name, &conn.BaseURL, &conn.APIKey, &conn.OAuthProvider, &conn.Format, &conn.ChatPath, &conn.AuthHeader, &conn.AuthPrefix, &conn.ExtraHeaders, &conn.IsActive, &conn.Priority, &conn.PoolID)
 	if err != nil {
 		return nil, fmt.Errorf("model not found: %s", model)
 	}
@@ -1979,7 +1988,7 @@ func (p *ProxyHandler) scanConnections(rows *sql.Rows) []*Connection {
 	var out []*Connection
 	for rows.Next() {
 		var conn Connection
-		if err := rows.Scan(&conn.ID, &conn.Name, &conn.BaseURL, &conn.APIKey, &conn.OAuthProvider, &conn.Format, &conn.ChatPath, &conn.AuthHeader, &conn.AuthPrefix, &conn.IsActive, &conn.Priority, &conn.PoolID); err != nil {
+		if err := rows.Scan(&conn.ID, &conn.Name, &conn.BaseURL, &conn.APIKey, &conn.OAuthProvider, &conn.Format, &conn.ChatPath, &conn.AuthHeader, &conn.AuthPrefix, &conn.ExtraHeaders, &conn.IsActive, &conn.Priority, &conn.PoolID); err != nil {
 			continue
 		}
 		p.applyConnectionAuth(&conn)
@@ -2011,7 +2020,7 @@ func (p *ProxyHandler) findAlternateConnectionsForModel(model string, excludeIDs
 	}
 
 	rows, err := p.db.Conn().Query(`
-		SELECT c.id, c.name, c.base_url, c.api_key, COALESCE(c.oauth_provider,''), c.format, c.chat_path, c.auth_header, c.auth_prefix, c.is_active, c.priority, COALESCE(c.pool_id,'')
+		SELECT c.id, c.name, c.base_url, c.api_key, COALESCE(c.oauth_provider,''), c.format, c.chat_path, c.auth_header, c.auth_prefix, COALESCE(c.extra_headers,'{}'), c.is_active, c.priority, COALESCE(c.pool_id,'')
 		FROM discovered_models m
 		JOIN connections c ON m.connection_id = c.id
 		WHERE m.model_id = ? AND m.is_active = 1 AND c.is_active = 1`+exclude+`
@@ -2026,7 +2035,7 @@ func (p *ProxyHandler) findAlternateConnectionsForModel(model string, excludeIDs
 
 func (p *ProxyHandler) getFirstConnection() (*Connection, error) {
 	row := p.db.Conn().QueryRow(`
-		SELECT id, name, base_url, api_key, COALESCE(oauth_provider,''), format, chat_path, auth_header, auth_prefix, is_active, priority, COALESCE(pool_id,'')
+		SELECT id, name, base_url, api_key, COALESCE(oauth_provider,''), format, chat_path, auth_header, auth_prefix, COALESCE(extra_headers,'{}'), is_active, priority, COALESCE(pool_id,'')
 		FROM connections
 		WHERE is_active = 1
 		ORDER BY priority DESC
@@ -2034,7 +2043,7 @@ func (p *ProxyHandler) getFirstConnection() (*Connection, error) {
 	`)
 
 	var conn Connection
-	err := row.Scan(&conn.ID, &conn.Name, &conn.BaseURL, &conn.APIKey, &conn.OAuthProvider, &conn.Format, &conn.ChatPath, &conn.AuthHeader, &conn.AuthPrefix, &conn.IsActive, &conn.Priority, &conn.PoolID)
+	err := row.Scan(&conn.ID, &conn.Name, &conn.BaseURL, &conn.APIKey, &conn.OAuthProvider, &conn.Format, &conn.ChatPath, &conn.AuthHeader, &conn.AuthPrefix, &conn.ExtraHeaders, &conn.IsActive, &conn.Priority, &conn.PoolID)
 	if err != nil {
 		return nil, fmt.Errorf("no active connections")
 	}

--- a/internal/server/proxy_provider_parity_test.go
+++ b/internal/server/proxy_provider_parity_test.go
@@ -185,15 +185,42 @@ func TestT2_Parity_CustomAuthHeader(t *testing.T) {
 	if legacy.path != sdk.path {
 		t.Errorf("chat_path mismatch: legacy=%q sdk=%q", legacy.path, sdk.path)
 	}
-	// FAITHFUL QUIRK: the live router (proxy.go:986-987) coerces an empty
-	// AuthPrefix to "Bearer " — there is no way to send a truly bare token.
-	// The SDK's DefaultProvider.Prepare reproduces this EXACTLY. Asserting the
-	// quirk (not an idealized behavior) is the whole point of zero-behavior-change:
-	// both paths must emit "Bearer sk-test-key" under a custom auth header too.
-	if got, want := sdk.header.Get("X-Api-Key"), "Bearer sk-test-key"; got != want {
-		t.Errorf("custom auth header value mismatch on SDK path: got %q want %q (the faithful empty-prefix quirk)", got, want)
+	// EMPTY PREFIX IS NOW A REAL VALUE for the x-api-key family. Anthropic's
+	// contract is `x-api-key: <bare key>` with NO prefix; the old coercion to
+	// "Bearer " made that preset impossible to satisfy. A bare key is now sent
+	// when the header is x-api-key, and BOTH paths must agree exactly.
+	if got, want := sdk.header.Get("X-Api-Key"), "sk-test-key"; got != want {
+		t.Errorf("custom auth header value mismatch on SDK path: got %q want %q (bare key, no prefix)", got, want)
 	}
-	if got := legacy.header.Get("X-Api-Key"); got != "Bearer sk-test-key" {
-		t.Errorf("legacy path did not exhibit the documented empty-prefix quirk: %q", got)
+	if got := legacy.header.Get("X-Api-Key"); got != "sk-test-key" {
+		t.Errorf("legacy path mismatch: got %q want %q (bare key, no prefix)", got, "sk-test-key")
+	}
+}
+
+// TestT2_Parity_EmptyPrefixNonApiKeyStillBearer locks the OTHER half of the
+// contract: the empty-prefix -> "Bearer " default must still apply for every
+// header that is not x-api-key, so no existing connection changes behavior.
+func TestT2_Parity_EmptyPrefixNonApiKeyStillBearer(t *testing.T) {
+	body := []byte(`{"model":"gpt-4o","messages":[]}`)
+	mk := func(baseURL string) *Connection {
+		c := openAICompatConn(baseURL, "openai")
+		c.AuthHeader = "Authorization"
+		c.AuthPrefix = ""
+		return c
+	}
+
+	var legacy capturedReq
+	lsrv := newCapturingUpstream(t, &legacy)
+	runDoUpstream(t, buildHandler(t, false), mk(lsrv.URL), body, http.Header{}, &legacy)
+
+	var sdk capturedReq
+	ssrv := newCapturingUpstream(t, &sdk)
+	runDoUpstream(t, buildHandler(t, true), mk(ssrv.URL), body, http.Header{}, &sdk)
+
+	if got, want := legacy.header.Get("Authorization"), "Bearer sk-test-key"; got != want {
+		t.Errorf("legacy: empty prefix with Authorization must still become %q, got %q", want, got)
+	}
+	if got, want := sdk.header.Get("Authorization"), "Bearer sk-test-key"; got != want {
+		t.Errorf("sdk: empty prefix with Authorization must still become %q, got %q", want, got)
 	}
 }


### PR DESCRIPTION
## Summary
- curate Add Connection presets to providers with verified model discovery contracts
- persist and use per-provider chat/models/auth/header capability metadata
- make Test, Save, auto-sync, runtime inference, and Usage labels honest and consistent
- migrate existing Google/Anthropic contracts safely and keep manual presets untouched

## Verification
- `go test ./internal/db ./internal/server ./internal/provider ./internal/discover -count=1` (490 passed)
- `go build ./...`
- `npm run check` (0 errors; existing warnings)
- `npm run build`
- `git diff --check`

## Known unrelated issue
- full `go test ./... -count=1`: 1259 passed, 1 flaky pre-existing failure in `internal/experimental.TestE1_ExitAfterOneIsContained` (`file already closed`); isolated x5 reproduced 1 failure.

No production deployment or restart performed.